### PR TITLE
create the model classes on deserializing from ORDS

### DIFF
--- a/jag-staffnet-biometrics-application/pom.xml
+++ b/jag-staffnet-biometrics-application/pom.xml
@@ -187,6 +187,11 @@
             <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.28</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/controllers/EnrollmentController.java
+++ b/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/controllers/EnrollmentController.java
@@ -1,10 +1,15 @@
 package ca.bc.gov.open.staffnet.controllers;
 
 import ca.bc.gov.open.staffnet.biometrics.one.*;
-import ca.bc.gov.open.staffnet.biometrics.two.ArrayOfIdentityName;
-import ca.bc.gov.open.staffnet.biometrics.two.BCeIDAccountTypeCode;
-import ca.bc.gov.open.staffnet.biometrics.two.IdentityName;
-import ca.bc.gov.open.staffnet.biometrics.two.ResponseCode;
+import ca.bc.gov.open.staffnet.biometrics.one.FinishEnrollmentWithIdCheck;
+import ca.bc.gov.open.staffnet.biometrics.one.FinishEnrollmentWithIdCheckRequest;
+import ca.bc.gov.open.staffnet.biometrics.one.FinishEnrollmentWithIdCheckResponse;
+import ca.bc.gov.open.staffnet.biometrics.one.FinishEnrollmentWithIdCheckResponse2;
+import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheck;
+import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheckRequest;
+import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheckResponse;
+import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheckResponse2;
+import ca.bc.gov.open.staffnet.biometrics.two.*;
 import ca.bc.gov.open.staffnet.configuration.SoapConfig;
 import ca.bc.gov.open.staffnet.exceptions.ORDSException;
 import ca.bc.gov.open.staffnet.models.*;
@@ -40,6 +45,9 @@ public class EnrollmentController {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final WebServiceTemplate webServiceTemplate;
+
+    private final String LEGAL = "LEGAL";
+    private final String KNOWNAS = "KNOWNAS";
 
     @Autowired
     public EnrollmentController(
@@ -86,9 +94,16 @@ public class EnrollmentController {
             startEnrollmentWithIdCheckRequest.setDid(inner.getDid());
             startEnrollmentWithIdCheckRequest.setDateOfBirth(resp.getBody().getDateOfBirth());
             startEnrollmentWithIdCheckRequest.setPhoto(resp.getBody().getPhotoBase64());
-            List<IdentityName> identityNameList = resp.getBody().getIdentityNames();
+            List<IdentityNameResponse> identityNameList = resp.getBody().getIdentityNames();
             ArrayOfIdentityName arrayOfIdentityName = new ArrayOfIdentityName();
-            arrayOfIdentityName.getIdentityName().addAll(identityNameList);
+            for ( var identityName: identityNameList) {
+                var in =  new IdentityName();
+                in.setType(identityName.getType().equalsIgnoreCase(LEGAL)?MatchIdentityNameType.LEGAL:MatchIdentityNameType.KNOWN_AS);
+                in.setGivenName(identityName.getGivenName());
+                in.setLastName(identityName.getLastName());
+                in.setMiddleName(identityName.getMiddleName());
+                arrayOfIdentityName.getIdentityName().add(in);
+            }
             startEnrollmentWithIdCheckRequest.setIdentityNames(arrayOfIdentityName);
         } catch (Exception ex) {
             log.error(

--- a/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/IdentityNameResponse.java
+++ b/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/IdentityNameResponse.java
@@ -1,0 +1,11 @@
+package ca.bc.gov.open.staffnet.models;
+import lombok.Data;
+import java.io.Serializable;
+
+@Data
+public class IdentityNameResponse implements Serializable {
+    protected String type;
+    protected String givenName;
+    protected String middleName;
+    protected String lastName;
+}

--- a/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/MatchIdentityNameTypeResponse.java
+++ b/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/MatchIdentityNameTypeResponse.java
@@ -1,0 +1,20 @@
+package ca.bc.gov.open.staffnet.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+
+public enum MatchIdentityNameTypeResponse {
+    LEGAL("Legal"),
+    KNOWNAS("KnownAs");
+
+    private String type;
+
+    MatchIdentityNameTypeResponse(String type) {
+        this.type = type;
+    }
+
+    @JsonValue
+    public String getType() {
+        return type;
+    }
+}

--- a/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/WorkerInfoResponse.java
+++ b/jag-staffnet-biometrics-application/src/main/java/ca/bc/gov/open/staffnet/models/WorkerInfoResponse.java
@@ -11,7 +11,7 @@ public class WorkerInfoResponse implements Serializable {
     private String did;
     private byte[] photoBase64;
     private String dateOfBirth;
-    private List<IdentityName> identityNames;
+    private List<IdentityNameResponse> identityNames;
     private ResponseCode responseCode;
     private String responseMessage;
 }

--- a/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/EnrollmentControllerTests.java
+++ b/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/EnrollmentControllerTests.java
@@ -9,6 +9,7 @@ import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheck;
 import ca.bc.gov.open.staffnet.biometrics.one.StartEnrollmentWithIdCheckRequest;
 import ca.bc.gov.open.staffnet.biometrics.two.*;
 import ca.bc.gov.open.staffnet.controllers.EnrollmentController;
+import ca.bc.gov.open.staffnet.models.IdentityNameResponse;
 import ca.bc.gov.open.staffnet.models.WorkerImageSetResponse;
 import ca.bc.gov.open.staffnet.models.WorkerInfoResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -56,12 +57,12 @@ public class EnrollmentControllerTests {
         workerInfoResponse.setResponseCode(ResponseCode.SUCCESS);
         workerInfoResponse.setDateOfBirth("A");
         workerInfoResponse.setPhotoBase64(new byte[0]);
-        List<IdentityName> identityNameList = new ArrayList<>();
-        IdentityName identityName = new IdentityName();
+        List<IdentityNameResponse> identityNameList = new ArrayList<>();
+        IdentityNameResponse identityName = new IdentityNameResponse();
         identityName.setGivenName("A");
         identityName.setLastName("A");
         identityName.setMiddleName("A");
-        identityName.setType(MatchIdentityNameType.LEGAL);
+        identityName.setType("LEGAL");
         identityNameList.add(identityName);
         workerInfoResponse.setIdentityNames(identityNameList);
         ResponseEntity<WorkerInfoResponse> responseEntity =

--- a/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/RefreshControllerTests.java
+++ b/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/RefreshControllerTests.java
@@ -9,6 +9,7 @@ import ca.bc.gov.open.staffnet.biometrics.two.IssuanceToken;
 import ca.bc.gov.open.staffnet.biometrics.two.MatchIdentityNameType;
 import ca.bc.gov.open.staffnet.biometrics.two.ResponseCode;
 import ca.bc.gov.open.staffnet.controllers.RefreshController;
+import ca.bc.gov.open.staffnet.models.IdentityNameResponse;
 import ca.bc.gov.open.staffnet.models.WorkerInfoResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,12 +51,12 @@ public class RefreshControllerTests {
         req.setRefreshIdentityWithIdCheckRequest(refreshIdentityWithIdCheckRequest);
 
         WorkerInfoResponse workerInfoResponse = new WorkerInfoResponse();
-        List<IdentityName> identityNameList = new ArrayList<>();
-        IdentityName identityName = new IdentityName();
+        List<IdentityNameResponse> identityNameList = new ArrayList<>();
+        IdentityNameResponse identityName = new IdentityNameResponse();
         identityName.setGivenName("A");
         identityName.setLastName("A");
         identityName.setMiddleName("A");
-        identityName.setType(MatchIdentityNameType.LEGAL);
+        identityName.setType("LEGAL");
         identityNameList.add(identityName);
         workerInfoResponse.setIdentityNames(identityNameList);
         workerInfoResponse.setResponseCode(ResponseCode.SUCCESS);

--- a/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/SoapSvcErrorTests.java
+++ b/jag-staffnet-biometrics-application/src/test/java/ca/bc/gov/open/staffnet/SoapSvcErrorTests.java
@@ -28,6 +28,7 @@ import ca.bc.gov.open.staffnet.controllers.EnrollmentController;
 import ca.bc.gov.open.staffnet.controllers.RefreshController;
 import ca.bc.gov.open.staffnet.controllers.SearchController;
 import ca.bc.gov.open.staffnet.models.GetEnrolledWorkersOutput;
+import ca.bc.gov.open.staffnet.models.IdentityNameResponse;
 import ca.bc.gov.open.staffnet.models.WorkerInfoResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -151,12 +152,12 @@ public class SoapSvcErrorTests {
         workerInfoResponse.setResponseCode(ResponseCode.SUCCESS);
         workerInfoResponse.setDateOfBirth("A");
         workerInfoResponse.setPhotoBase64(new byte[0]);
-        List<IdentityName> identityNameList = new ArrayList<>();
-        IdentityName identityName = new IdentityName();
+        List<IdentityNameResponse> identityNameList = new ArrayList<>();
+        IdentityNameResponse identityName = new IdentityNameResponse();
         identityName.setGivenName("A");
         identityName.setLastName("A");
         identityName.setMiddleName("A");
-        identityName.setType(MatchIdentityNameType.LEGAL);
+        identityName.setType("LEGAL");
         identityNameList.add(identityName);
         workerInfoResponse.setIdentityNames(identityNameList);
         ResponseEntity<WorkerInfoResponse> responseEntity =
@@ -234,12 +235,12 @@ public class SoapSvcErrorTests {
                 new RefreshController(restTemplate, objectMapper, webServiceTemplate);
 
         WorkerInfoResponse workerInfoResponse = new WorkerInfoResponse();
-        List<IdentityName> identityNameList = new ArrayList<>();
-        IdentityName identityName = new IdentityName();
+        List<IdentityNameResponse> identityNameList = new ArrayList<>();
+        IdentityNameResponse identityName = new IdentityNameResponse();
         identityName.setGivenName("A");
         identityName.setLastName("A");
         identityName.setMiddleName("A");
-        identityName.setType(MatchIdentityNameType.LEGAL);
+        identityName.setType("LEGAL");
         identityNameList.add(identityName);
         workerInfoResponse.setIdentityNames(identityNameList);
         workerInfoResponse.setResponseCode(ResponseCode.SUCCESS);

--- a/jag-staffnet-identity-provisioning-application/pom.xml
+++ b/jag-staffnet-identity-provisioning-application/pom.xml
@@ -188,6 +188,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.28</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
refreshIdentityWithIdCheck request got an error on extracting response in production environment. the Java 11 and Spring 2 reused the auto-generated class from xsd as ORDS deserializing conversion classes and it worked, but Java17/Spring 3 does not allow it anymore.
So, I have to manually generate a java class to conversion ORDS response from JSON to class objects.